### PR TITLE
use #!/usr/bin/env instead of /bin/env

### DIFF
--- a/compare.py
+++ b/compare.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import json
 import jsondiff


### PR DESCRIPTION
Proposal to use /usr/bin/env instead of /bin/env. The former seem to be more common. For instance on macOS /bin/env do not exist.

In CentOS 7, both are the same (hardlinked)